### PR TITLE
chore: validate the repository against HACS in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate
+
+# HACS runs these checks itself before it will list a repository, and the default-list
+# reviewers look for a green run here. The nightly schedule is the point of it: the checks
+# read GitHub metadata — description, topics, issues, releases — that can go stale without
+# a commit to notice it.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: plugin


### PR DESCRIPTION
Adds the `hacs/action` validation workflow, which the HACS default-list review expects to be green.

Together with the repository description and topics (set directly on GitHub), this clears the three automated checks that were failing: `description`, `topics`, and the absence of a validation run.

The nightly schedule is the point of the cron: the checks read GitHub metadata that can go stale without a commit to notice it.